### PR TITLE
foces.reduce_doublefber: a background estimation for the flat is adde…

### DIFF
--- a/gamse/echelle/extract.py
+++ b/gamse/echelle/extract.py
@@ -8,6 +8,7 @@ import scipy.interpolate as intp
 import scipy.optimize as opt
 import astropy.io.fits as fits
 import matplotlib.pyplot as plt
+import math
 
 from .imageproc import table_to_array
 from ..utils.onedarray import pairwise, smooth
@@ -113,7 +114,8 @@ def sum_extract(infilename, mskfilename, outfilename, channels, apertureset_lst,
 
             # determine the upper and lower row of summing
             r1 = int(lower_line.min())
-            r2 = int(upper_line.max())+1
+            r2 = int(math.ceil(upper_line.max()))+1
+
             mask = mask[r1:r2]
 
             # summing the data and mask
@@ -201,7 +203,7 @@ def extract_aperset(data, mask, apertureset, lower_limit=5, upper_limit=5,
 
         ## determine the upper and lower row of summing
         r1 = int(lower_line.min())
-        r2 = int(upper_line.max())+1
+        r2 = int(math.ceil(upper_line.max()))+1
 
         # summing the data and mask
         weight_sum = newmask[r1:r2].sum(axis=0)

--- a/gamse/pipelines/foces/__init__.py
+++ b/gamse/pipelines/foces/__init__.py
@@ -144,8 +144,8 @@ def make_config():
     # section of spectra extraction
     sectname = 'reduce.extract'
     config.add_section(sectname)
-    config.set(sectname, 'upper_limit', str(6))
-    config.set(sectname, 'lower_limit', str(6))
+    config.set(sectname, 'upper_limit', str(4.5))
+    config.set(sectname, 'lower_limit', str(4.5))
 
     # write to config file
     filename = 'FOCES.{}.cfg'.format(input_date)


### PR DESCRIPTION
…d to the gamse output; in addition what before was named 'flat' in the onedspec is now named 'blaze'

foces.__init__: the upper and the lower limit in '[reduce.extract]' was set from 6 to 4.5 as default
echelle.extract: the problem #53 was solved be enlarging the evaluated extraction region